### PR TITLE
Fix CI testing config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - "develop"
-      - "master"
+      - "*"
   pull_request:
     branches:
       - "*"


### PR DESCRIPTION
A small oversight in the CI configuration. Now testing should be performed on the main branch as well.